### PR TITLE
Ignore virtual environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,148 @@
+# Byte-compiled / optimized / DLL files
 __pycache__/
+*.py[cod]
+*$py.class
+
+# Ignore vscode workbench configuration
 .vscode/
+
+# Phantom files
+# Ignored files related to Phantom
 Data/
 .DS_Store
 cogs/adminserver.py
 bot.log
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/README.md
+++ b/README.md
@@ -1,26 +1,44 @@
 # Phantom
 Phantom is my personal Discord bot written with [discord.py](https://discordpy.readthedocs.io/en/stable/) aimed at replacing the functionality of other major Discord bots!
 
-## Requirements
-- A Linux or macOS PC
-    - Windows is untested
+You can invite Phantom into any Discord server using [this](https://discord.com/api/oauth2/authorize?client_id=736756253333913670&permissions=1279257670&scope=bot) link.
 
 ## Setup
-To locally host, follow these steps:
+To host your own instance, you'll need a Discord bot with "Server Members" intent enabled.
 
-0. Create a [Discord Bot](https://discord.com/developers/applications/).
-    - Under the bot menu, make sure to enable the 'Server Members Intent'.
+1. Download the project using Git (or any other method)
 
-1. Install the required Python libraries:
-`pip3 install -r requirements.txt`
+2. Install the required Python libraries. You'll need Python 3.9 or later
 
-2. Set the `PHANTOM_TOKEN` environment variable to your bot token.
+        # Linux/macOS
+        pip3 install -U -r requirements.txt
 
-3. Run `bot.py`:
-`python3 bot.py`
+        # Windows
+        pip install -U -r requirements.txt
 
-## Invite
-Phantom can be invited into any Discord server using [this](https://discord.com/api/oauth2/authorize?client_id=736756253333913670&permissions=1279257670&scope=bot) link.
+    You might want to create and use a virtual environment before installing the requirements
+
+        # Linux/macOS
+        python3 -m venv --upgrade-deps env; source env/bin/activate
+
+        # Windows
+        py -m venv --upgrade-deps env; .\env\Scripts\activate
+
+3. Set the `PHANTOM_TOKEN` environment variable to your token
+
+    For Linux/macOS, you can export the variable inside your shell configuration file
+
+    For Windows, you'll need to find a way to get to your "Environment Variables" panel. It can be found within Control Panel
+
+4. Run the bot script
+
+        # Linux/macOS
+        python3 bot.py
+
+        # Windows
+        py bot.py
+
+    If everything was set up correctly, your instance should start
 
 ## Support
 For any questions/issues you have, join my [Discord](https://m1sta.xyz/discord) server.


### PR DESCRIPTION
This PR allows Git to ignore created env's within the project itself. This also adds information about using a virtual environment rather than installing requirements globally, while also updating and adding instructions (for Windows)